### PR TITLE
fix: send proof ack

### DIFF
--- a/client/src/pages/useCase/Section.tsx
+++ b/client/src/pages/useCase/Section.tsx
@@ -72,7 +72,7 @@ export const Section: React.FC<Props> = ({
   const next = () => dispatch(nextStep())
 
   const isConnectionCompleted = connection.state === 'response-sent' || connection.state === 'completed'
-  const isProofCompleted = proof?.state === 'presentation-received'
+  const isProofCompleted = proof?.state === 'presentation-received' || proof?.state === 'done'
   const credentialsReceived = Object.values(credentials).every(
     (x) => x.state === 'credential-issued' || x.state === 'done'
   )

--- a/client/src/pages/useCase/steps/StepProof.tsx
+++ b/client/src/pages/useCase/steps/StepProof.tsx
@@ -25,7 +25,7 @@ export interface Props {
 
 export const StepProof: React.FC<Props> = ({ proof, step, connectionId, requestedCredentials, entity }) => {
   const dispatch = useAppDispatch()
-  const proofReceived = proof?.state === 'presentation-received'
+  const proofReceived = proof?.state === 'presentation-received' || proof?.state === 'done'
 
   const [isFailedRequestModalOpen, setIsFailedRequestModalOpen] = useState(false)
   const showFailedRequestModal = () => setIsFailedRequestModalOpen(true)


### PR DESCRIPTION
this updates the demo to send a proof ack after the presentation has been verified. This is part of the protocol, but the trinsic wallet doesn't support it and will throw an error. It's needed for the bifold based wallets (holdr+, bc). Don't have to merge now, but if we want to support these wallets we will need to merge this. Not sure what to do with the trinsic wallet. They're not updating it anymore 🤷 