### PR TITLE
fix: Disabled strictmode for cypress execution

### DIFF
--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { createRoot } from 'react-dom/client'
 import { Provider } from 'react-redux'
 import { BrowserRouter } from 'react-router-dom'
@@ -14,7 +15,8 @@ const container = document.getElementById('root')
 
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const root = createRoot(container!)
-root.render(
+
+const content = (
   <Provider store={store}>
     <PersistGate loading={null} persistor={persistor}>
       <BrowserRouter>
@@ -25,3 +27,12 @@ root.render(
     </PersistGate>
   </Provider>
 )
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+if (window.Cypress) {
+  // Cypress is running, don't use StrictMode because it doesn't really like the double execution of effects in StrictMode
+  root.render(content)
+} else {
+  root.render(<React.StrictMode>{content}</React.StrictMode>)
+}


### PR DESCRIPTION
This will make it possible to still run the application in development mode but without strict mode. This will give us the ability to get the strict errors in development and to run the e2e testing with cypress.